### PR TITLE
Add plugin support for etherpad subdirectory install

### DIFF
--- a/static/js/hooks.js
+++ b/static/js/hooks.js
@@ -12,7 +12,7 @@ exports.aceInitialized = function(hook, context){
 
 // CSS styling of editor
 exports.aceInitInnerdocbodyHead = function(hook_name, args, cb) {
-  args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="/static/plugins/ep_mathjax/static/css/ace.css"/>');
+  args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="../static/plugins/ep_mathjax/static/css/ace.css"/>');
   return cb();
 };
 

--- a/templates/scripts.ejs
+++ b/templates/scripts.ejs
@@ -1,1 +1,1 @@
-<script src="/static/plugins/ep_mathjax/static/js/main.js"></script>
+<script src="../static/plugins/ep_mathjax/static/js/main.js"></script>

--- a/templates/styles.ejs
+++ b/templates/styles.ejs
@@ -1,1 +1,1 @@
-<link rel="stylesheet" href="/static/plugins/ep_mathjax/static/css/main.css" type="text/css" />
+<link rel="stylesheet" href="../static/plugins/ep_mathjax/static/css/main.css" type="text/css" />


### PR DESCRIPTION
I use your plugin in my experimentation, when i tried to use in on etherpad subdirectory install (url like "http://MYURL/etherpad/" for etherpad front page) i got a trouble. 
Your plugin will search their file on static URL like http://MYURL/static/js/main.js instead of http://MYURL/etherpad/static/js/main.js due to absolute path.
The paths I changed don't seems to modify how your plugin work in other case but it now works on subdirectory install. 
Please, create a new version. 